### PR TITLE
Reintroduce lint for checking translations, fix broken deploy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-  build:
+  build-and-test:
     docker:
       - image: circleci/node:9
     steps:
@@ -16,8 +16,8 @@ jobs:
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
-      - run: yarn build
-  build-and-deploy:
+      - run: yarn lint
+  build-test-and-deploy:
     docker:
       - image: circleci/node:9
     steps:
@@ -41,10 +41,10 @@ jobs:
           command: yarn deploy
 workflows:
   version: 2
-  build:
+  build-and-test:
     jobs:
-      - build
-      - build-and-deploy:
+      - build-and-test
+      - build-test-and-deploy:
           filters:
             branches:
               only: master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ jobs:
           key: yarn-packages-{{ checksum "yarn.lock" }}
           paths:
             - ~/.cache/yarn
+      - run: yarn build
       - run: yarn lint
   build-test-and-deploy:
     docker:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ yarn serve
 # To deploy the site. This happens automatically on a successful merge.
 yarn deploy
 
-# To run lint
+# To run lint (just checks completeness of translations at the moment)
 yarn lint
 ```
 

--- a/package.json
+++ b/package.json
@@ -20,13 +20,11 @@
   },
   "scripts": {
     "build": "./scripts/build",
-    "deploy:force":
-      "yarn build && gh-pages -d build/ -t -m \"Updated website [skip ci]\"",
+    "deploy:force": "yarn build && gh-pages -d build/ -t -m \"Updated website [skip ci]\"",
     "deploy": "./scripts/deploy",
     "lint": "./scripts/lint",
     "watch:build": "watch \"yarn build\" src/ locales/ scripts/",
-    "serve":
-      "concurrently --kill-others \"live-server ./build\" \"yarn watch:build\"",
+    "serve": "concurrently --kill-others \"live-server ./build\" \"yarn watch:build\"",
     "start": "yarn serve"
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,10 +20,13 @@
   },
   "scripts": {
     "build": "./scripts/build",
-    "deploy:force": "yarn build && gh-pages -d build/ -t -m \"Updated website [skip ci]\"",
+    "deploy:force":
+      "yarn build && gh-pages -d build/ -t -m \"Updated website [skip ci]\"",
     "deploy": "./scripts/deploy",
+    "lint": "./scripts/lint",
     "watch:build": "watch \"yarn build\" src/ locales/ scripts/",
-    "serve": "concurrently --kill-others \"live-server ./build\" \"yarn watch:build\"",
+    "serve":
+      "concurrently --kill-others \"live-server ./build\" \"yarn watch:build\"",
     "start": "yarn serve"
   }
 }

--- a/scripts/lint
+++ b/scripts/lint
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+
+# do everything in a subshell
+(
+  # colors for output
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  BLUE='\033[0;34m'
+  DARK_GRAY='\033[1;30m'
+  NO_COLOR='\033[0m'
+
+  function getScriptLocation()
+  {
+    local source="${BASH_SOURCE[0]}"
+    while [ -h "$source" ]; do # resolve $source until the file is no longer a symlink
+      local sourceDir="$( cd -P "$( dirname "$source" )" && pwd )"
+      local source="$(readlink "$source")"
+      [[ $source != /* ]] && source="$sourceDir/$source" # if $source was a relative symlink, we need to resolve it relative to the path where the symlink file was located
+    done
+    echo "$( cd -P "$( dirname "$source" )" && pwd )"
+  }
+
+  scriptDir=$(getScriptLocation)
+  rootDir=$(dirname "$scriptDir")
+  buildDir="$rootDir/build"
+
+  echo -e "${BLUE}Checking if all english locale strings are present in other languages.${NO_COLOR}"
+  node "$rootDir/scripts/checkLocaleKeys.js" "$rootDir/locales"
+
+  if ! [ $? -eq 0 ]; then
+    echo -e "${RED}Error: Locales are invalid, aborting${NO_COLOR}"
+    exit 1
+  fi
+
+  echo -e "${DARK_GRAY}Building${NO_COLOR}"
+  yarn build
+
+  if ! [ $? -eq 0 ]; then
+    echo -e "${RED}Build failed${NO_COLOR}"
+    exit 1
+  fi
+
+  invalidHTMLExists=0
+  for htmlFile in $(find "$buildDir" -name "*.html"); do
+    echo -e "${BLUE}===========================${NO_COLOR}"
+    echo -e "${BLUE}Checking $htmlFile${NO_COLOR}"
+    echo -e "${BLUE}===========================${NO_COLOR}\n"
+
+    npx amphtml-validator $htmlFile
+
+    if ! [ $? -eq 0 ]; then
+      echo -e "\n${RED}${htmlFile} is invalid AMP HTML.${NO_COLOR}"
+      invalidHTMLExists=1
+    fi
+  done
+
+  if ! [ $invalidHTMLExists -eq 0 ]; then
+    echo -e "${RED}Invalid AMP HTML was present, aborting.${NO_COLOR}"
+    exit 1
+  fi
+
+  echo -e "${GREEN}Lint passed${NO_COLOR}"
+)

--- a/scripts/lint
+++ b/scripts/lint
@@ -32,32 +32,5 @@
     exit 1
   fi
 
-  echo -e "${DARK_GRAY}Building${NO_COLOR}"
-  yarn build
-
-  if ! [ $? -eq 0 ]; then
-    echo -e "${RED}Build failed${NO_COLOR}"
-    exit 1
-  fi
-
-  invalidHTMLExists=0
-  for htmlFile in $(find "$buildDir" -name "*.html"); do
-    echo -e "${BLUE}===========================${NO_COLOR}"
-    echo -e "${BLUE}Checking $htmlFile${NO_COLOR}"
-    echo -e "${BLUE}===========================${NO_COLOR}\n"
-
-    npx amphtml-validator $htmlFile
-
-    if ! [ $? -eq 0 ]; then
-      echo -e "\n${RED}${htmlFile} is invalid AMP HTML.${NO_COLOR}"
-      invalidHTMLExists=1
-    fi
-  done
-
-  if ! [ $invalidHTMLExists -eq 0 ]; then
-    echo -e "${RED}Invalid AMP HTML was present, aborting.${NO_COLOR}"
-    exit 1
-  fi
-
   echo -e "${GREEN}Lint passed${NO_COLOR}"
 )


### PR DESCRIPTION
Deploy referred to lint; it was no longer there.

Also there is a lint check that actually was valid, so keep that in there. Revert changes that remove lint altogether and just modify lint script to just do translation validation.